### PR TITLE
Tags ordering still matters

### DIFF
--- a/autoload/ctrlp/tjump.vim
+++ b/autoload/ctrlp/tjump.vim
@@ -57,9 +57,8 @@ endfunction
 " Return: a Vim's List
 "
 function! ctrlp#tjump#init()
-  " let input = map(s:order_tags(), 'v:key + 1 . "\t" . v:val["kind"] . "\t" . v:val["name"] . "\t" . s:short_filename(v:val["filename"]) . "\t" . v:val["cmd"]')
-  " let input = map(s:taglist, 'v:key + 1 . "\t" . v:val["kind"] . "\t" . v:val["name"] . "\t" . s:short_filename(v:val["filename"]) . "\t" . v:val["cmd"]')
-  let input = map(s:taglist, 'v:key + 1 . "\t" . v:val["kind"] . "\t" . (g:ctrlp_tjump_skip_tag_name ? "" : v:val["name"] . "\t") . s:short_filename(v:val["filename"]) . "\t" . v:val["cmd"]')
+  let input = map(s:order_tags(), 'v:key + 1 . "\t" . v:val["kind"] . "\t" . (g:ctrlp_tjump_skip_tag_name ? "" : v:val["name"] . "\t") . s:short_filename(v:val["filename"]) . "\t" . v:val["cmd"]')
+  " let input = map(s:taglist, 'v:key + 1 . "\t" . v:val["kind"] . "\t" . (g:ctrlp_tjump_skip_tag_name ? "" : v:val["name"] . "\t") . s:short_filename(v:val["filename"]) . "\t" . v:val["cmd"]')
 
   if !ctrlp#nosy()
     cal ctrlp#hicheck('CtrlPTabExtra', 'Comment')


### PR DESCRIPTION
This logic is changed in commit [#9c76b44b](https://github.com/ivalkeen/vim-ctrlp-tjump/commit/9c76b44bab10e8849ea73e32aa39838020f40475),
I encounter a weird behaviour today. After hitting
`ctrl + ]`, I jumped to a wrong file. By reverting to
old logic which uses `s:order_tags()`, jumping is ok now.

```
$ vim --version
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Oct 19 2015 17:09:38)
MacOS X (unix) version
Included patches: 1-898
Compiled by Homebrew
```