### PR TITLE
Pause case insensitivity to speed up searching

### DIFF
--- a/autoload/ctrlp/tjump.vim
+++ b/autoload/ctrlp/tjump.vim
@@ -30,6 +30,8 @@ call add(g:ctrlp_ext_vars, {
       \ })
 
 function! ctrlp#tjump#exec(mode)
+  let ignorecase_save = &ignorecase
+  set noignorecase
   if a:mode == 'v'
     let s:word = s:get_visual_selection()
   else
@@ -46,10 +48,11 @@ function! ctrlp#tjump#exec(mode)
   if len(s:taglist) == 0
     echo("No tags found for: ".s:word)
   elseif len(s:taglist) == 1 && g:ctrlp_tjump_only_silent == 1
-    call feedkeys(":silent! tag ".s:word."\r", 'nt')
+    exe "silent! tag ".s:word
   else
     call ctrlp#init(ctrlp#tjump#id())
   endif
+  let &ignorecase = ignorecase_save
 endfunction
 
 " Provide a list of strings to search in


### PR DESCRIPTION
Disabling case sensitivity prevents vim from using a binary search
when searching the tags list. Temporarily disabling 'ignorecase'
allows for much faster searches.