### PR TITLE
Fix tag priority

### DIFF
--- a/autoload/ctrlp/tjump.vim
+++ b/autoload/ctrlp/tjump.vim
@@ -191,7 +191,7 @@ endfunction
 
 " Return the FSC priority string of a tag, see :help tag-priority
 function! s:priority(tgi)
-  let c_full_match = s:word == a:tgi['name'] ? 'F' : ' '
+  let c_full_match = s:word ==# a:tgi['name'] ? 'F' : ' '
   let c_static_tag = 1 == a:tgi['static'] ? 'S' : ' '
   let c_current_file = s:bname == fnamemodify(a:tgi['filename'], ':p') ? 'C' : ' '
   let priority = c_full_match.c_static_tag.c_current_file


### PR DESCRIPTION
When user sets `set ignorecase`, `s:word == a:tgi['name']` will return true even the case doesn't match, which will cause the order incorrect. With `==#`, the result will be correct.