### PR TITLE
Fix tagorder when the argument contains a pattern

### DIFF
--- a/autoload/ctrlp/tjump.vim
+++ b/autoload/ctrlp/tjump.vim
@@ -1,3 +1,4 @@
+
 if (exists('g:loaded_ctrlp_tjump') && g:loaded_ctrlp_tjump)
       \ || v:version < 700 || &cp
   finish
@@ -44,11 +45,19 @@ function! ctrlp#tjump#exec(mode, ...)
     en
   endif
 
-  let s:taglist = taglist('^'.s:word.'$')
+  if s:word =~ '^/'
+    " treat word starting with / as a regexp, see :help tag-regexp
+    let taglistexpr = strpart(s:word, 1)
+  else
+    " treat word as literal and construct an exact match regexp
+    let taglistexpr = '^'.escape(s:word, '^$.*~\').'$'
+  endif
+  " unlike :tag and :tselect, taglist always expect a regular expression
+  let s:taglist = taglist(taglistexpr)
   let s:bname = fnamemodify(bufname('%'), ':p')
 
   if len(s:taglist) == 0
-    echo("No tags found for: ".s:word)
+    echo('No tags found for: '.s:word.' (expr: '.taglistexpr.')')
   elseif len(s:taglist) == 1 && g:ctrlp_tjump_only_silent == 1
     call feedkeys(":silent! tag ".s:word."\r", 'nt')
   else


### PR DESCRIPTION
If the argument does not start with '/' then always treat it as a word
literal by escaping it properly for taglist. This behaviour is
consistent with ":tag" and ":stag", meaning that the jump will actually go
to the correct tag location. To get the best performance it is important
that the pattern taglist starts with exactly '^', else the binary search
seems to be skipped.

When argument is a pattern starting with '/', don't add the exact match
match anchors '^' and '$'.

:help taglist
taglist({expr}) Returns a list of tags matching the regular expression
{expr}

:help tag-regexp
The ":tag" and ":tselect" commands accept a regular expression argument.
When the argument starts with '/', it is used as a pattern.  If the argument
does not start with '/', it is taken literally, as a full tag name.