### PR TITLE
Don't pollute command history when jumping to a single match

### DIFF
--- a/autoload/ctrlp/tjump.vim
+++ b/autoload/ctrlp/tjump.vim
@@ -50,7 +50,7 @@ function! ctrlp#tjump#exec(mode, ...)
   if len(s:taglist) == 0
     echo("No tags found for: ".s:word)
   elseif len(s:taglist) == 1 && g:ctrlp_tjump_only_silent == 1
-    call feedkeys(":silent! tag ".s:word."\r", 'nt')
+    exec ":silent! tag ".s:word
   else
     call ctrlp#init(ctrlp#tjump#id())
   endif


### PR DESCRIPTION
When doing a jump for which only one match is found, `feedkeys()` is used
to execute the `tag` command. This results in such command being recorded
in the command history, to avoid that `feedkeys()` call is replaced with
`exec` command.